### PR TITLE
Feat: Quantum Teleportation Chapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,36 @@
 # ------------------------------------------------------------------------------
-#  Install the notebook
+#  Install the mdbook toolchain
 # ------------------------------------------------------------------------------
 .PHONY: install
 install: 
 	cargo install mdbook
+	cargo install mdbook-tabs
 
 
 # ------------------------------------------------------------------------------
-#  Uninstall the notebook
+#  Uninstall the mdbook toolchain
 # ------------------------------------------------------------------------------
 .PHONY: uninstall
 uninstall: 
 	cargo uninstall mdbook
-
+	cargo uninstall mdbook-tabs
 
 # ------------------------------------------------------------------------------
-#  Build the notebook
+#  Build the mdbook
 # ------------------------------------------------------------------------------
 .PHONY: build
 build: 
 	mdbook build
 
 # ------------------------------------------------------------------------------
-#  Run the notebook
+#  Run the mdbook
 # ------------------------------------------------------------------------------
 .PHONY: run
 run: 
 	mdbook serve --open
 
 # ------------------------------------------------------------------------------
-#  Clean the notebook
+#  Clean the mdbook
 # ------------------------------------------------------------------------------
 .PHONY: clean
 clean: 

--- a/src/quantum/quantum_information.md
+++ b/src/quantum/quantum_information.md
@@ -623,7 +623,255 @@ Still limited by linear optics constraints.
 
 ## Quantum Teleportation
 
-Coming soon!
+### Overview
+
+Quantum teleportation is a protocol that transfers an **unknown quantum state** from one location to another using:
+
+- Entanglement
+- Classical communication
+
+Key idea:
+
+- The quantum state is **not copied**
+- The original is **destroyed**
+- The state is **reconstructed** at the destination
+
+### The Problem
+
+Given an unknown qubit:
+
+\\[
+|\psi\rangle = \alpha|0\rangle + \beta|1\rangle
+\\]
+
+Goal:
+
+\\[
+|\psi\rangle_A \rightarrow |\psi\rangle_B
+\\]
+
+Naively, one might try:
+
+\\[
+|\psi\rangle |0\rangle \rightarrow |\psi\rangle |\psi\rangle
+\\]
+
+This is **impossible**.
+
+### No-Cloning Theorem
+
+Unknown quantum states cannot be copied.
+
+Reason:
+
+Linearity implies:
+
+\\[
+C(\alpha|0\rangle + \beta|1\rangle)
+= \alpha C|0\rangle + \beta C|1\rangle
+\\]
+
+But cloning would require:
+
+\\[
+(\alpha|0\rangle + \beta|1\rangle)(\alpha|0\rangle + \beta|1\rangle)
+\\]
+
+These expressions are not equal for general \\( \\alpha, \\beta \\).
+
+Conclusion:
+
+- Cloning is impossible
+- State must be **transferred**, not duplicated
+
+### Initial Setup
+
+Three qubits:
+
+- Qubit 1: unknown state \\( |\\psi\\rangle \\) (Alice)
+- Qubit 2: entangled (Alice)
+- Qubit 3: entangled (Bob)
+
+Shared Bell state:
+
+\\[
+|\Phi^+\rangle\_{23} =
+\frac{1}{\sqrt{2}}(|00\rangle + |11\rangle)
+\\]
+
+Ownership:
+
+- Alice → qubits 1 and 2
+- Bob → qubit 3
+
+### Total Initial State
+
+\\[
+|\Psi\rangle =
+|\psi\rangle*1 \otimes |\Phi^+\rangle*{23}
+\\]
+
+\\[
+= (\alpha|0\rangle + \beta|1\rangle)
+\frac{1}{\sqrt{2}}(|00\rangle + |11\rangle)
+\\]
+
+This is a **three-qubit system**.
+
+### Bell States
+
+\\[
+|\Phi^\pm\rangle =
+\frac{1}{\sqrt{2}}(|00\rangle \pm |11\rangle)
+\\]
+
+\\[
+|\Psi^\pm\rangle =
+\frac{1}{\sqrt{2}}(|01\rangle \pm |10\rangle)
+\\]
+
+These form a complete basis for two qubits.
+
+### Bell Basis Expansion
+
+The total state can be rewritten as:
+
+\\[
+|\Psi\rangle =
+\frac{1}{2} \Big(|\Phi^+\rangle\_{12} (\alpha|0\rangle + \beta|1\rangle)\_3
++|\Phi^-\rangle\_{12} (\alpha|0\rangle - \beta|1\rangle)\_3
++|\Psi^+\rangle\_{12} (\alpha|1\rangle + \beta|0\rangle)\_3
++|\Psi^-\rangle\_{12} (\alpha|1\rangle - \beta|0\rangle)\_3\Big)
+\\]
+
+Key insight:
+
+- Alice’s measurement outcome determines Bob’s state
+
+### Measurement by Alice
+
+Alice performs a **Bell-state measurement** on qubits 1 and 2.
+
+Result:
+
+- One of four Bell states
+- Produces **2 classical bits**
+
+After measurement:
+
+- Original state is destroyed
+- Bob’s qubit collapses into a related state
+
+### Conditional States at Bob
+
+| Alice Outcome           | Bob’s State                                |
+| ----------------------- | ------------------------------------------ |
+| \\( \|\Phi^+\rangle \\) | \\( \alpha\|0\rangle + \beta\|1\rangle \\) |
+| \\( \|\Phi^-\rangle \\) | \\( \alpha\|0\rangle - \beta\|1\rangle \\) |
+| \\( \|\Psi^+\rangle \\) | \\( \alpha\|1\rangle + \beta\|0\rangle \\) |
+| \\( \|\Psi^-\rangle \\) | \\( \alpha\|1\rangle - \beta\|0\rangle \\) |
+
+Bob has a **modified version** of \\( |\\psi\\rangle \\).
+
+### Classical Communication
+
+Alice sends **2 classical bits** to Bob.
+
+Important:
+
+- Without this, Bob cannot recover the state
+- No faster-than-light communication
+
+### Correction by Bob
+
+Bob applies an operation depending on Alice’s result:
+
+| Bits | Operation  |
+| ---- | ---------- |
+| 00   | \\( I \\)  |
+| 01   | \\( Z \\)  |
+| 10   | \\( X \\)  |
+| 11   | \\( XZ \\) |
+
+After correction:
+
+\\[
+|\psi\rangle_B = \alpha|0\rangle + \beta|1\rangle
+\\]
+
+### Final Result
+
+- Bob obtains the original quantum state
+- Alice’s state is destroyed
+
+\\[
+|\psi\rangle_A \rightarrow |\psi\rangle_B
+\\]
+
+No duplication occurs.
+
+### Physical Implementation (Optical Systems)
+
+Qubits represented by polarization:
+
+- \\( |H\\rangle \\) = horizontal
+- \\( |V\\rangle \\) = vertical
+
+Components:
+
+- Beam splitter (BS)
+- Polarizing beam splitters (PBS)
+- Detectors
+
+Bell-state analyzer:
+
+- Can distinguish only some Bell states
+
+### Practical Limitation
+
+Linear optics can distinguish:
+
+\\[
+|\Psi^+\rangle, \quad |\Psi^-\rangle
+\\]
+
+But not:
+
+\\[
+|\Phi^+\rangle, \quad |\Phi^-\rangle
+\\]
+
+Result:
+
+\\[
+P\_{\text{success}} = \frac{1}{2}
+\\]
+
+Teleportation is probabilistic in practice.
+
+### Conceptual Flow
+
+1. Entanglement shared
+2. Alice entangles unknown with Bell pair
+3. Alice measures (destroys original state)
+4. Classical bits sent to Bob
+5. Bob applies correction
+6. State reconstructed
+
+### Conceptual Takeaways
+
+- Quantum information cannot be copied
+- Entanglement enables state transfer
+- Classical communication is required
+- Information is transferred, not particles
+- Measurement redistributes quantum information
+
+### Common Misconceptions
+
+- Teleportation does not move matter
+- Entanglement alone does not transmit information
+- The state does not exist in two places
+- Classical communication is essential
 
 ---
 

--- a/src/quantum/quantum_information.md
+++ b/src/quantum/quantum_information.md
@@ -737,11 +737,7 @@ These form a complete basis for two qubits.
 The total state can be rewritten as:
 
 \\[
-|\Psi\rangle =
-\frac{1}{2} \Big(|\Phi^+\rangle_{12} (\alpha|0\rangle + \beta|1\rangle)_3
-+|\Phi^-\rangle_{12} (\alpha|0\rangle - \beta|1\rangle)_3
-+|\Psi^+\rangle_{12} (\alpha|1\rangle + \beta|0\rangle)_3
-+|\Psi^-\rangle_{12} (\alpha|1\rangle - \beta|0\rangle)_3\Big)
+|\Psi\rangle = \frac{1}{2} \Big(|\Phi^+\rangle\_{12} (\alpha|0\rangle + \beta|1\rangle)\_3 - |\Phi^-\rangle\_{12} (\alpha|0\rangle - \beta|1\rangle)\_3 - |\Psi^+\rangle\_{12} (\alpha|1\rangle + \beta|0\rangle)\_3 - |\Psi^-\rangle\_{12} (\alpha|1\rangle - \beta|0\rangle)\_3\Big)
 \\]
 
 Key insight:

--- a/src/quantum/quantum_information.md
+++ b/src/quantum/quantum_information.md
@@ -738,10 +738,10 @@ The total state can be rewritten as:
 
 \\[
 |\Psi\rangle =
-\frac{1}{2} \Big(|\Phi^+\rangle\_{12} (\alpha|0\rangle + \beta|1\rangle)\_3
-+|\Phi^-\rangle\_{12} (\alpha|0\rangle - \beta|1\rangle)\_3
-+|\Psi^+\rangle\_{12} (\alpha|1\rangle + \beta|0\rangle)\_3
-+|\Psi^-\rangle\_{12} (\alpha|1\rangle - \beta|0\rangle)\_3\Big)
+\frac{1}{2} \Big(|\Phi^+\rangle_{12} (\alpha|0\rangle + \beta|1\rangle)_3
++|\Phi^-\rangle_{12} (\alpha|0\rangle - \beta|1\rangle)_3
++|\Psi^+\rangle_{12} (\alpha|1\rangle + \beta|0\rangle)_3
++|\Psi^-\rangle_{12} (\alpha|1\rangle - \beta|0\rangle)_3\Big)
 \\]
 
 Key insight:

--- a/src/quantum/quantum_information.md
+++ b/src/quantum/quantum_information.md
@@ -708,7 +708,7 @@ Ownership:
 
 \\[
 |\Psi\rangle =
-|\psi\rangle*1 \otimes |\Phi^+\rangle*{23}
+|\psi\rangle_1 \otimes |\Phi^+\rangle_{23}
 \\]
 
 \\[

--- a/src/quantum/quantum_information.md
+++ b/src/quantum/quantum_information.md
@@ -844,7 +844,7 @@ But not:
 Result:
 
 \\[
-P\_{\text{success}} = \frac{1}{2}
+P_{\text{success}} = \frac{1}{2}
 \\]
 
 Teleportation is probabilistic in practice.

--- a/src/quantum/quantum_information.md
+++ b/src/quantum/quantum_information.md
@@ -695,7 +695,7 @@ Three qubits:
 Shared Bell state:
 
 \\[
-|\Phi^+\rangle\_{23} =
+|\Phi^+\rangle_{23} =
 \frac{1}{\sqrt{2}}(|00\rangle + |11\rangle)
 \\]
 


### PR DESCRIPTION
This pull request introduces a detailed explanation of quantum teleportation to the `src/quantum/quantum_information.md` documentation and updates the `Makefile` to improve the installation and uninstallation of the `mdbook` toolchain. The most important changes are grouped below:

**Documentation Enhancements:**

* Added a comprehensive section on quantum teleportation, covering the protocol steps, the no-cloning theorem, Bell states, measurement and correction procedures, physical implementation with optical systems, practical limitations, conceptual flow, and common misconceptions.

**Build Tooling Improvements:**

* Updated the `Makefile` to install and uninstall `mdbook-tabs` alongside `mdbook`, ensuring all required tools for building and serving the documentation are managed together.