### PR TITLE
Backport 2026-03-23

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,19 +49,19 @@ src/
 
 The `mdbook-tabs` plugin enables tabbed content via preprocessor directives:
 
-````markdown
+```markdown
 {{#tabs}}
 
 {{#tab name="Tab 1"}}
 Content for tab 1.
-{{/tab}}
+{{/endtab}}
 
 {{#tab name="Tab 2"}}
 Content for tab 2.
-{{/tab}}
+{{/endtab}}
 
-{{/tabs}}
-````
+{{/endtabs}}
+```
 
 ## Math Rendering
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,16 +47,20 @@ src/
 
 ## Tabbed Content Syntax
 
-The `mdbook-tabs` plugin enables tabbed code blocks:
+The `mdbook-tabs` plugin enables tabbed content via preprocessor directives:
 
 ````markdown
-```tabs
-[[Tab Title 1]]
-Content for tab 1
+{{#tabs}}
 
-[[Tab Title 2]]
-Content for tab 2
-```
+{{#tab name="Tab 1"}}
+Content for tab 1.
+{{/tab}}
+
+{{#tab name="Tab 2"}}
+Content for tab 2.
+{{/tab}}
+
+{{/tabs}}
 ````
 
 ## Math Rendering

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,16 +46,18 @@ src/
 
 ## Tabbed Content Syntax
 
-The `mdbook-tabs` plugin enables tabbed code blocks:
+The `mdbook-tabs` plugin enables tabbed content using `{{#tabs}}` / `{{#tab name="..."}}` directives (this matches the syntax used under `src/design_patterns/`):
 
 ````markdown
-```tabs
-[[Tab Title 1]]
+{{#tabs}}
+{{#tab name="Tab Title 1"}}
 Content for tab 1
+{{/tab}}
 
-[[Tab Title 2]]
+{{#tab name="Tab Title 2"}}
 Content for tab 2
-```
+{{/tab}}
+{{/tabs}}
 ````
 
 ## Math Rendering

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ make clean      # Remove the ./book build artifact
 ```
 
 Raw alternatives if `make` is unavailable:
+
 ```bash
 mdbook build
 mdbook serve --open
@@ -48,21 +49,24 @@ src/
 
 The `mdbook-tabs` plugin enables tabbed content using `{{#tabs}}` / `{{#tab name="..."}}` directives (this matches the syntax used under `src/design_patterns/`):
 
-````markdown
+```markdown
 {{#tabs}}
+
 {{#tab name="Tab Title 1"}}
 Content for tab 1
-{{/tab}}
+{{/endtab}}
 
 {{#tab name="Tab Title 2"}}
 Content for tab 2
-{{/tab}}
-{{/tabs}}
-````
+{{/endtab}}
+
+{{/endtabs}}
+```
 
 ## Math Rendering
 
 MathJax is enabled. Use standard LaTeX delimiters:
+
 - Inline: `\\( expression \\)`
 - Block: `\\[ expression \\]`
 


### PR DESCRIPTION
This pull request updates the documentation in both `AGENTS.md` and `CLAUDE.md` to clarify and standardize the syntax for creating tabbed content using the `mdbook-tabs` plugin. The main focus is on improving the examples and explanations for how to use tabbed content in markdown files.

Tabbed content syntax improvements:

* Updated the description and examples in `AGENTS.md` to show the use of `{{#tabs}}` and `{{#tab name="..."}}` directives for tabbed content, replacing the older code block-based syntax.
* Revised the explanation and example in `CLAUDE.md` to match the new tabbed content syntax and ensure consistency with other documentation sections.